### PR TITLE
feat: added pagination on users, conversation and messages

### DIFF
--- a/backend/apps/conversations/api/views/conversation.py
+++ b/backend/apps/conversations/api/views/conversation.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from apps.conversations.api.serializers.conversation import ConversationSerializer
 from apps.conversations.models import Conversation
+from apps.conversations.pagination import ConversationCursorPagination
 from apps.conversations.services.conversation_service import (
     get_or_create_direct_conversation,
 )
@@ -17,11 +18,19 @@ class ConversationView(APIView):
 
     def get(self, request):
         user = request.user
-        conversations = Conversation.objects.filter(participant__user=user)
-        return Response(
-            data=ConversationSerializer(conversations, many=True).data,
-            status=status.HTTP_200_OK,
+
+        conversations = Conversation.objects.filter(participant__user=user).order_by(
+            "-updated_at"
         )
+
+        paginator = ConversationCursorPagination()
+        paginated_conversations = paginator.paginate_queryset(
+            conversations, request, view=self
+        )
+
+        serializer = ConversationSerializer(paginated_conversations, many=True)
+
+        return paginator.get_paginated_response(serializer.data)
 
     def post(self, request):
         sender = request.user

--- a/backend/apps/conversations/api/views/message.py
+++ b/backend/apps/conversations/api/views/message.py
@@ -9,6 +9,7 @@ from apps.conversations.api.serializers.message import (
     SendMessageSerializer,
 )
 from apps.conversations.models import Conversation, Message
+from apps.conversations.pagination import MessageCursorPagination
 from apps.conversations.permissions import IsConversationParticipant
 from apps.conversations.services.message_service import create_message
 
@@ -20,16 +21,21 @@ class MessageView(APIView):
         return get_object_or_404(Conversation, id=conversation_id)
 
     # TODO: @msulemanb exclude soft deleted messages from this list (in future)
-    def get(self, __request__, conversation_id):
+    def get(self, request, conversation_id):
         """Get list of messages of a single conversation"""
         conversation = self.get_conversation(conversation_id)
+
         messages = Message.objects.filter(conversation=conversation).order_by(
-            "created_at"
+            "-created_at"
         )
 
-        return Response(
-            MessageSerializer(messages, many=True).data, status=status.HTTP_200_OK
-        )
+        paginator = MessageCursorPagination()
+
+        paginated_messages = paginator.paginate_queryset(messages, request, view=self)
+
+        serializer = MessageSerializer(paginated_messages, many=True)
+
+        return paginator.get_paginated_response(serializer.data)
 
     def post(self, request, conversation_id):
         conversation = self.get_conversation(conversation_id)

--- a/backend/apps/conversations/pagination.py
+++ b/backend/apps/conversations/pagination.py
@@ -1,0 +1,11 @@
+from rest_framework.pagination import CursorPagination, PageNumberPagination
+
+
+class MessageCursorPagination(CursorPagination):
+    page_size = 30
+    ordering = "-created_at"
+
+
+class ConversationCursorPagination(PageNumberPagination):
+    page_size = 10
+    ordering = "-updated_at"

--- a/backend/apps/users/api/views/user.py
+++ b/backend/apps/users/api/views/user.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.api.serializers.user import UserSerializer
+from apps.users.pagination import StandardPagination
 
 
 class UserDetailView(APIView):
@@ -63,6 +64,7 @@ class UserDetailView(APIView):
 
 class UsersListView(APIView):
     permission_classes = [IsAuthenticated]
+    pagination_class = StandardPagination
 
     def get(self, request):
         search = request.query_params.get("search", "")
@@ -76,5 +78,8 @@ class UsersListView(APIView):
                 | Q(last_name__icontains=search)
             )
 
-        serializer = UserSerializer(users, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        paginator = StandardPagination()
+        paginated_users = paginator.paginate_queryset(users, request, view=self)
+
+        serializer = UserSerializer(paginated_users, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/backend/apps/users/pagination.py
+++ b/backend/apps/users/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardPagination(PageNumberPagination):
+    page_size = 10


### PR DESCRIPTION
Added ConversationCursorPagination in Messages of a single convo
Added PageNumberPagination in Conversations list and Users list

NOTE:
1. We used CursorPagination for messages in a single conversation because chat data is time-ordered, frequently growing, and needs stable infinite scrolling without shifting results when new messages arrive.

2. We used PageNumberPagination for conversations and users lists because they are searchable, less time-sensitive directory-style data where random access (page 1, 2, 3) and simple navigation are more practical than cursor-based traversal.