### PR TITLE
feat: add vercel.json rewrite rules for SPA routing

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Issue:
Classic SPA routing issue on Vercel. Your React Router routes work fine in-app (because the JS handles them client-side), but on hard reload or direct visit (/invite/abc123, /login), Vercel's static file server looks for a file at that path, doesn't find one, and returns its own 404 page.

